### PR TITLE
Update to 1.1.1

### DIFF
--- a/_build/resolvers/events.resolver.php
+++ b/_build/resolvers/events.resolver.php
@@ -76,6 +76,7 @@ function removeEvent(xPDO $modx, $name)
 
 $events = [
     'OnCursusEventParticipantBooked',
+    'OnCursusEventParticipantRestored',
 ];
 
 /** @var xPDO $modx */

--- a/core/components/commerce_cursus/docs/changelog.txt
+++ b/core/components/commerce_cursus/docs/changelog.txt
@@ -1,3 +1,10 @@
+Cursus for Commerce 1.1.1-pl
+---------------------------------
+TBA
+
+- Check expired reservations before a Commerce step
+- Invoke OnCursusEventParticipantRestored when an expired event participant was marked as booked
+
 Cursus for Commerce 1.1.0-pl
 ---------------------------------
 Released on 2024-04-19

--- a/core/components/commerce_cursus/elements/plugins/commerce_cursus.plugin.php
+++ b/core/components/commerce_cursus/elements/plugins/commerce_cursus.plugin.php
@@ -12,22 +12,17 @@
 $className = 'modmore\Commerce_Cursus\Plugins\Events\\' . $modx->event->name;
 
 $corePath = $modx->getOption('commerce_cursus.core_path', null, $modx->getOption('core_path') . 'components/commerce_cursus/');
-/** @var Commerce_Cursus $commerce_cursus */
-$commerce_cursus = $modx->getService('commerce_cursus', 'Commerce_Cursus', $corePath . 'model/commerce_cursus/', [
-    'core_path' => $corePath
-]);
+require_once $corePath . '/vendor/autoload.php';
 
-if ($commerce_cursus) {
-    if (class_exists($className)) {
-        $handler = new $className($modx, $scriptProperties);
-        if (get_class($handler) == $className) {
-            $handler->run();
-        } else {
-            $modx->log(xPDO::LOG_LEVEL_ERROR, $className. ' could not be initialized!', '', 'Commerce_Cursus Plugin');
-        }
+if (class_exists($className)) {
+    $handler = new $className($modx, $scriptProperties);
+    if (get_class($handler) == $className) {
+        $handler->run();
     } else {
-        $modx->log(xPDO::LOG_LEVEL_ERROR, $className. ' was not found!', '', 'Commerce_Cursus Plugin');
+        $modx->log(xPDO::LOG_LEVEL_ERROR, $className . ' could not be initialized!', '', 'Commerce_Cursus Plugin');
     }
+} else {
+    $modx->log(xPDO::LOG_LEVEL_ERROR, $className . ' was not found!', '', 'Commerce_Cursus Plugin');
 }
 
 return;


### PR DESCRIPTION
- Autoload the plugin event classes directly
- Check expired reservations before a Commerce step
- Invoke OnCursusEventParticipantRestored when an expired event participant was marked as booked
