### PR TITLE
Update to 1.2.1

### DIFF
--- a/_build/data/settings.php
+++ b/_build/data/settings.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'commerce_cursus.set_email_from_order' => [
+    'set_email_from_order' => [
         'xtype' => 'combo-boolean',
         'area' => 'system',
         'value' => '0',

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -25,12 +25,12 @@ foreach ($settingSource as $key => $options) {
     /** @var modSystemSetting */
     $setting = $modx->newObject('modSystemSetting');
     $setting->fromArray([
-        'key' => 'scheduler.' . $key,
+        'key' => 'commerce_cursus.' . $key,
         'xtype' => $xtype,
         'value' => $options['value'],
-        'namespace' => 'scheduler',
+        'namespace' => 'commerce_cursus',
         'area' => $options['area'],
-        'editedon' => time(),
+        'editedon' => NULL,
     ], '', true, true);
     $settings[] = $setting;
 }

--- a/core/components/commerce_cursus/docs/changelog.txt
+++ b/core/components/commerce_cursus/docs/changelog.txt
@@ -9,6 +9,7 @@ Cursus for Commerce 1.2.0-pl
 Released on 2025-07-29
 
 - Add the CommerceCursusDemoCartOrderPrepare FormIt hook to show how Cursus participants can be created, assigned as participant to the Cursus event and added to the Commerce cart
+- Add the system setting commerce_cursus.set_email_from_order to set the email of the Cursus participant by the email address in the Commerce order
 
 Cursus for Commerce 1.1.3-pl
 ----------------------------

--- a/core/components/commerce_cursus/src/Module.php
+++ b/core/components/commerce_cursus/src/Module.php
@@ -141,8 +141,10 @@ class Module extends BaseModule
         $participantProfile = $participant->getOne('Profile');
         $address = $order->getBillingAddress();
         if ($participantProfile && $address) {
-            $participantProfile->set('email', $address->get('email'));
-            $participantProfile->save();
+            if ($this->adapter->getOption('commerce_cursus.set_email_from_order')) {
+                $participantProfile->set('email', $address->get('email'));
+                $participantProfile->save();
+            }
             $this->commerce->modx->invokeEvent('OnCursusEventParticipantBooked', [
                 'order' => &$order,
                 'address' => &$address,


### PR DESCRIPTION
- Add the CommerceCursusDemoCartOrderPrepare FormIt hook to show how Cursus participants can be created, assigned as participant to the Cursus event and added to the Commerce cart
- Add the system setting commerce_cursus.set_email_from_order to set the email of the Cursus participant by the email address in the Commerce order
